### PR TITLE
Add alias 'user-error'

### DIFF
--- a/doc-present.el
+++ b/doc-present.el
@@ -231,6 +231,10 @@ rightmost column will be.")
 
 ;; Code
 
+;; `user-error' isn't defined in Emacs < 24.3
+(unless (fboundp 'user-error)
+  (defalias 'user-error 'error))
+
 (defun doc-present ()
   (interactive)
   (when doc-view-current-converter-processes


### PR DESCRIPTION
`user-error` is introduced at Emacs 24.3. This fix is for Emacs 24.1 and Emacs 24.2.
Please check this patch.
